### PR TITLE
Scaffold interaction class

### DIFF
--- a/app/assets/stylesheets/interactions.scss
+++ b/app/assets/stylesheets/interactions.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Interactions controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: http://sass-lang.com/

--- a/app/controllers/interactions_controller.rb
+++ b/app/controllers/interactions_controller.rb
@@ -1,0 +1,58 @@
+class InteractionsController < ApplicationController
+  before_action :set_interaction, only: [:show, :edit, :update, :destroy]
+
+  def index
+    @interactions = Interaction.all
+  end
+
+  def show; end
+
+  def new
+    @interaction = Interaction.new
+  end
+
+  def edit; end
+
+  def create
+    @interaction = Interaction.new(interaction_params)
+
+    respond_to do |format|
+      if @interaction.save
+        format.html { redirect_to @interaction, notice: t('interaction.controller.create.success') }
+      else
+        format.html { render :new }
+        format.json { render json: @interaction.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def update
+    respond_to do |format|
+      if @interaction.update(interaction_params)
+        format.html { redirect_to @interaction, notice: t('interaction.controller.update.success') }
+      else
+        format.html { render :edit }
+        format.json { render json: @interaction.errors, status: :unprocessable_entity }
+      end
+    end
+  end
+
+  def destroy
+    @interaction.destroy
+    respond_to do |format|
+      format.html { redirect_to interactions_url, notice: t('interaction.controller.destroy.success') }
+      format.json { head :no_content }
+    end
+  end
+
+  private
+
+    def set_interaction
+      @interaction = Interaction.find(params[:id])
+    end
+
+    def interaction_params
+      params.require(:interaction).permit(:reciprocator_id,
+                                          :listing_id)
+    end
+end

--- a/app/helpers/interactions_helper.rb
+++ b/app/helpers/interactions_helper.rb
@@ -1,0 +1,2 @@
+module InteractionsHelper
+end

--- a/app/models/interaction.rb
+++ b/app/models/interaction.rb
@@ -1,0 +1,4 @@
+class Interaction < ApplicationRecord
+  belongs_to :reciprocator, foreign_key: 'reciprocator_id', class_name: 'Participant'
+  belongs_to :listing
+end

--- a/app/views/interactions/_form.html.erb
+++ b/app/views/interactions/_form.html.erb
@@ -1,0 +1,27 @@
+<%= form_with(model: interaction, local: true) do |form| %>
+  <% if interaction.errors.any? %>
+    <div id="error_explanation">
+      <h2><%= pluralize(interaction.errors.count, "error") %> prohibited this interaction from being saved:</h2>
+
+      <ul>
+      <% interaction.errors.full_messages.each do |message| %>
+        <li><%= message %></li>
+      <% end %>
+      </ul>
+    </div>
+  <% end %>
+
+  <div class="field">
+    <%= form.label :reciprocator_id %>
+    <%= form.text_field :reciprocator_id %>
+  </div>
+
+  <div class="field">
+    <%= form.label :listing_id %>
+    <%= form.text_field :listing_id %>
+  </div>
+
+  <div class="actions">
+    <%= form.submit %>
+  </div>
+<% end %>

--- a/app/views/interactions/edit.html.erb
+++ b/app/views/interactions/edit.html.erb
@@ -1,0 +1,6 @@
+<h1>Editing Interaction</h1>
+
+<%= render 'form', interaction: @interaction %>
+
+<%= link_to 'Show', @interaction %> |
+<%= link_to 'Back', interactions_path %>

--- a/app/views/interactions/index.html.erb
+++ b/app/views/interactions/index.html.erb
@@ -1,0 +1,29 @@
+<p id="notice"><%= notice %></p>
+
+<h1>Interactions</h1>
+
+<table>
+  <thead>
+    <tr>
+      <th>Reciprocator</th>
+      <th>Listing</th>
+      <th colspan="3"></th>
+    </tr>
+  </thead>
+
+  <tbody>
+    <% @interactions.each do |interaction| %>
+      <tr>
+        <td><%= interaction.reciprocator.id %></td>
+        <td><%= interaction.listing.id %></td>
+        <td><%= link_to 'Show', interaction %></td>
+        <td><%= link_to 'Edit', edit_interaction_path(interaction) %></td>
+        <td><%= link_to 'Destroy', interaction, method: :delete, data: { confirm: 'Are you sure?' } %></td>
+      </tr>
+    <% end %>
+  </tbody>
+</table>
+
+<br>
+
+<%= link_to 'New Interaction', new_interaction_path %>

--- a/app/views/interactions/new.html.erb
+++ b/app/views/interactions/new.html.erb
@@ -1,0 +1,5 @@
+<h1>New Interaction</h1>
+
+<%= render 'form', interaction: @interaction %>
+
+<%= link_to 'Back', interactions_path %>

--- a/app/views/interactions/show.html.erb
+++ b/app/views/interactions/show.html.erb
@@ -1,0 +1,14 @@
+<p id="notice"><%= notice %></p>
+
+<p>
+  <strong>Reciprocator:</strong>
+  <%= @interaction.reciprocator.id %>
+</p>
+
+<p>
+  <strong>Listing:</strong>
+  <%= @interaction.listing.id %>
+</p>
+
+<%= link_to 'Edit', edit_interaction_path(@interaction) %> |
+<%= link_to 'Back', interactions_path %>

--- a/config/locales/en.yml
+++ b/config/locales/en.yml
@@ -39,3 +39,11 @@ en:
         success: 'Listing was successfully updated.'
       destroy:
         success: 'Listing was successfully destroyed.'
+  interaction:
+    controller:
+      create:
+        success: 'Interaction was successfully created.'
+      update:
+        success: 'Interaction was successfully updated.'
+      destroy:
+        success: 'Interaction was successfully destroyed.'

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,4 +1,6 @@
 Rails.application.routes.draw do
+  resources :interactions
+  resources :referral_codes
   devise_for :users, controllers: {
     registrations: 'users/registrations'
   }

--- a/db/migrate/20190331181059_create_interactions.rb
+++ b/db/migrate/20190331181059_create_interactions.rb
@@ -1,0 +1,10 @@
+class CreateInteractions < ActiveRecord::Migration[5.2]
+  def change
+    create_table :interactions do |t|
+      t.belongs_to :reciprocator, foreign_key: { to_table: :participants }
+      t.belongs_to :listing, foreign_key: true
+
+      t.timestamps
+    end
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,10 +10,19 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 2019_03_31_165546) do
+ActiveRecord::Schema.define(version: 2019_03_31_181059) do
 
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
+
+  create_table "interactions", force: :cascade do |t|
+    t.bigint "reciprocator_id"
+    t.bigint "listing_id"
+    t.datetime "created_at", null: false
+    t.datetime "updated_at", null: false
+    t.index ["listing_id"], name: "index_interactions_on_listing_id"
+    t.index ["reciprocator_id"], name: "index_interactions_on_reciprocator_id"
+  end
 
   create_table "listings", force: :cascade do |t|
     t.bigint "created_by_id"
@@ -104,6 +113,8 @@ ActiveRecord::Schema.define(version: 2019_03_31_165546) do
     t.index ["unlock_token"], name: "index_users_on_unlock_token", unique: true
   end
 
+  add_foreign_key "interactions", "listings"
+  add_foreign_key "interactions", "participants", column: "reciprocator_id"
   add_foreign_key "listings", "participants", column: "created_by_id"
   add_foreign_key "participants", "users"
   add_foreign_key "referral_codes", "participants"

--- a/spec/controllers/interactions_controller_spec.rb
+++ b/spec/controllers/interactions_controller_spec.rb
@@ -1,0 +1,132 @@
+require 'rails_helper'
+require 'pry'
+
+RSpec.describe InteractionsController, type: :controller do
+  before do
+    user = User.create!(email: 'person@example.com', password: 'xyz123456', confirmed_at: Time.now)
+    sign_in user
+  end
+
+  let(:participant) do
+    Participant.create!(user: User.create!(email: 'jo@lala.com', password: 'qwerty', confirmed_at: Time.now))
+  end
+
+  let(:listing_creator) do
+    Participant.create!(user: User.create!(email: 'jimmy@corporate.com', password: 'password', confirmed_at: Time.now))
+  end
+
+  let(:listing) do
+    Listing.create!(creator: listing_creator, type: "Offering")
+  end
+
+  let(:interaction) do
+    Interaction.create! valid_attributes
+  end
+
+  let(:valid_attributes) do
+    {
+      reciprocator_id: participant.id,
+      listing_id: listing.id
+    }
+  end
+
+  let(:valid_session) { {} }
+
+  describe "GET #index" do
+    it "returns a success response" do
+      interaction
+      get :index, params: {}, session: valid_session
+      expect(assigns(:interactions)).to eq([interaction])
+    end
+  end
+
+  describe "GET #show" do
+    it "returns a success response" do
+      interaction = Interaction.create! valid_attributes
+      get :show, params: {id: interaction.to_param}, session: valid_session
+      expect(response).to be_successful
+    end
+  end
+
+  describe "GET #new" do
+    it "returns a success response" do
+      get :new, params: {}, session: valid_session
+      expect(response).to be_successful
+    end
+  end
+
+  describe "GET #edit" do
+    it "returns a success response" do
+      interaction = Interaction.create! valid_attributes
+      get :edit, params: {id: interaction.to_param}, session: valid_session
+      expect(response).to be_successful
+    end
+  end
+
+  describe "POST #create" do
+    context "with valid params" do
+      it "creates a new Interaction" do
+        expect {
+          post :create, params: {interaction: valid_attributes}, session: valid_session
+        }.to change(Interaction, :count).by(1)
+      end
+
+      it "redirects to the created interaction" do
+        post :create, params: {interaction: valid_attributes}, session: valid_session
+        expect(response).to redirect_to(Interaction.last)
+      end
+    end
+
+    context "with invalid params" do
+      it "returns a success response (i.e. to display the 'new' template)" do
+        post :create, params: {interaction: invalid_attributes}, session: valid_session
+        expect(response).to be_successful
+      end
+    end
+  end
+
+  describe "PUT #update" do
+    context "with valid params" do
+      let(:new_attributes) {
+        skip("Add a hash of attributes valid for your model")
+      }
+
+      it "updates the requested interaction" do
+        interaction = Interaction.create! valid_attributes
+        put :update, params: {id: interaction.to_param, interaction: new_attributes}, session: valid_session
+        interaction.reload
+        skip("Add assertions for updated state")
+      end
+
+      it "redirects to the interaction" do
+        interaction = Interaction.create! valid_attributes
+        put :update, params: {id: interaction.to_param, interaction: valid_attributes}, session: valid_session
+        expect(response).to redirect_to(interaction)
+      end
+    end
+
+    context "with invalid params" do
+      it "returns a success response (i.e. to display the 'edit' template)" do
+        interaction = Interaction.create! valid_attributes
+        put :update, params: {id: interaction.to_param, interaction: invalid_attributes}, session: valid_session
+        expect(response).to be_successful
+      end
+    end
+  end
+
+  describe "DELETE #destroy" do
+    it "destroys the requested interaction" do
+      interaction = Interaction.create! valid_attributes
+      expect {
+        delete :destroy, params: {id: interaction.to_param}, session: valid_session
+      }.to change(Interaction, :count).by(-1)
+    end
+
+    it "redirects to the interactions list" do
+      interaction = Interaction.create! valid_attributes
+      delete :destroy, params: {id: interaction.to_param}, session: valid_session
+      expect(response).to redirect_to(interactions_url)
+    end
+  end
+
+end

--- a/spec/helpers/interactions_helper_spec.rb
+++ b/spec/helpers/interactions_helper_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+# Specs in this file have access to a helper object that includes
+# the InteractionsHelper. For example:
+#
+# describe InteractionsHelper do
+#   describe "string concat" do
+#     it "concats two strings with spaces" do
+#       expect(helper.concat_strings("this","that")).to eq("this that")
+#     end
+#   end
+# end
+RSpec.describe InteractionsHelper, type: :helper do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/models/interaction_spec.rb
+++ b/spec/models/interaction_spec.rb
@@ -1,0 +1,5 @@
+require 'rails_helper'
+
+RSpec.describe Interaction, type: :model do
+  pending "add some examples to (or delete) #{__FILE__}"
+end

--- a/spec/requests/interactions_spec.rb
+++ b/spec/requests/interactions_spec.rb
@@ -1,0 +1,10 @@
+require 'rails_helper'
+
+RSpec.describe "Interactions", type: :request do
+  describe "GET /interactions" do
+    it "works! (now write some real specs)" do
+      get interactions_path
+      expect(response).to have_http_status(200)
+    end
+  end
+end

--- a/spec/routing/interactions_routing_spec.rb
+++ b/spec/routing/interactions_routing_spec.rb
@@ -1,0 +1,38 @@
+require "rails_helper"
+
+RSpec.describe InteractionsController, type: :routing do
+  describe "routing" do
+    it "routes to #index" do
+      expect(:get => "/interactions").to route_to("interactions#index")
+    end
+
+    it "routes to #new" do
+      expect(:get => "/interactions/new").to route_to("interactions#new")
+    end
+
+    it "routes to #show" do
+      expect(:get => "/interactions/1").to route_to("interactions#show", :id => "1")
+    end
+
+    it "routes to #edit" do
+      expect(:get => "/interactions/1/edit").to route_to("interactions#edit", :id => "1")
+    end
+
+
+    it "routes to #create" do
+      expect(:post => "/interactions").to route_to("interactions#create")
+    end
+
+    it "routes to #update via PUT" do
+      expect(:put => "/interactions/1").to route_to("interactions#update", :id => "1")
+    end
+
+    it "routes to #update via PATCH" do
+      expect(:patch => "/interactions/1").to route_to("interactions#update", :id => "1")
+    end
+
+    it "routes to #destroy" do
+      expect(:delete => "/interactions/1").to route_to("interactions#destroy", :id => "1")
+    end
+  end
+end

--- a/spec/views/interactions/edit.html.erb_spec.rb
+++ b/spec/views/interactions/edit.html.erb_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe "interactions/edit", type: :view do
+  before(:each) do
+    @interaction = assign(:interaction, Interaction.create!(
+      :reciprocator => nil,
+      :listing => nil
+    ))
+  end
+
+  it "renders the edit interaction form" do
+    render
+
+    assert_select "form[action=?][method=?]", interaction_path(@interaction), "post" do
+
+      assert_select "input[name=?]", "interaction[reciprocator_id]"
+
+      assert_select "input[name=?]", "interaction[listing_id]"
+    end
+  end
+end

--- a/spec/views/interactions/index.html.erb_spec.rb
+++ b/spec/views/interactions/index.html.erb_spec.rb
@@ -1,0 +1,22 @@
+require 'rails_helper'
+
+RSpec.describe "interactions/index", type: :view do
+  before(:each) do
+    assign(:interactions, [
+      Interaction.create!(
+        :reciprocator => nil,
+        :listing => nil
+      ),
+      Interaction.create!(
+        :reciprocator => nil,
+        :listing => nil
+      )
+    ])
+  end
+
+  it "renders a list of interactions" do
+    render
+    assert_select "tr>td", :text => nil.to_s, :count => 2
+    assert_select "tr>td", :text => nil.to_s, :count => 2
+  end
+end

--- a/spec/views/interactions/new.html.erb_spec.rb
+++ b/spec/views/interactions/new.html.erb_spec.rb
@@ -1,0 +1,21 @@
+require 'rails_helper'
+
+RSpec.describe "interactions/new", type: :view do
+  before(:each) do
+    assign(:interaction, Interaction.new(
+      :reciprocator => nil,
+      :listing => nil
+    ))
+  end
+
+  it "renders new interaction form" do
+    render
+
+    assert_select "form[action=?][method=?]", interactions_path, "post" do
+
+      assert_select "input[name=?]", "interaction[reciprocator_id]"
+
+      assert_select "input[name=?]", "interaction[listing_id]"
+    end
+  end
+end

--- a/spec/views/interactions/show.html.erb_spec.rb
+++ b/spec/views/interactions/show.html.erb_spec.rb
@@ -1,0 +1,16 @@
+require 'rails_helper'
+
+RSpec.describe "interactions/show", type: :view do
+  before(:each) do
+    @interaction = assign(:interaction, Interaction.create!(
+      :reciprocator => nil,
+      :listing => nil
+    ))
+  end
+
+  it "renders attributes in <p>" do
+    render
+    expect(rendered).to match(//)
+    expect(rendered).to match(//)
+  end
+end


### PR DESCRIPTION
Resolves #017 

For Discussion: 
* It's still unclear what the consensus is on which test categories are to remain in rspec: controllers, factories, helpers, models, requests, routing, views. 
* I started on controllers, but most in group appeared to think it was not necessary.

### Description
Added interaction scaffold 
The interaction model includes reference to a 
- `listing_id`  which refers to a Listing
- `reciprocal_id` which refers to a Participant that is reciprocating on the Listing. We used reciprocal_id instead of participant_id, as every interaction includes 2 participants: one that creates a listing, and one that reciprocates. 

### Type of change
* Bug fix (non-breaking change which fixes an issue)
* New feature (non-breaking change which adds functionality)

### How Has This Been Tested?
I've tested locally/manually 
* by adding a Participant via the rails console and several listings.
* then went to http://localhost:3000/interactions and created/read/edited/destroyed an interaction.
