### PR TITLE
Brantron deploy fix

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -20,6 +20,11 @@ jobs:
       - checkout
 
       - run:
+          name: install dependencies
+          command: |
+            gem install bundler -v 2.0.1
+
+      - run:
           name: Which bundler?
           command: bundle -v
 

--- a/Gemfile
+++ b/Gemfile
@@ -19,7 +19,7 @@ gem 'uglifier', '>= 1.3.0'
 gem 'webpacker', '4.0.0'
 gem 'bootstrap', '~> 4.3.1'
 
-gem "aws-sdk-s3", require: false
+# gem "aws-sdk-s3", require: false
 
 gem 'image_processing', '~> 1.2'
 

--- a/Gemfile
+++ b/Gemfile
@@ -11,12 +11,12 @@ gem 'jbuilder', '~> 2.5'
 gem 'pg', '>= 0.18', '< 2.0'
 gem 'puma', '~> 3.11'
 gem 'rails', '~> 5.2.2', '>= 5.2.2.1'
-gem 'webpacker-react'
+gem 'webpacker-react', '0.3.2'
 
 gem 'sassc-rails'
 gem 'turbolinks', '~> 5'
 gem 'uglifier', '>= 1.3.0'
-gem 'webpacker'
+gem 'webpacker', '4.0.0'
 gem 'bootstrap', '~> 4.3.1'
 
 gem "aws-sdk-s3", require: false

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -82,7 +82,7 @@ GEM
       bundler (>= 1.2.0, < 3)
       thor (~> 0.18)
     byebug (11.0.1)
-    capybara (3.16.0)
+    capybara (3.16.1)
       addressable
       mini_mime (>= 0.1.3)
       nokogiri (~> 1.8)
@@ -158,7 +158,7 @@ GEM
     nokogiri (1.10.2)
       mini_portile2 (~> 2.4.0)
     orm_adapter (0.5.0)
-    parallel (1.16.2)
+    parallel (1.17.0)
     parser (2.6.2.0)
       ast (~> 2.4.0)
     pg (1.1.4)
@@ -169,7 +169,7 @@ GEM
     psych (3.1.0)
     public_suffix (3.0.3)
     puma (3.12.1)
-    rack (2.0.6)
+    rack (2.0.7)
     rack-proxy (0.6.5)
       rack
     rack-test (1.1.0)
@@ -203,7 +203,7 @@ GEM
     rb-fsevent (0.10.3)
     rb-inotify (0.10.0)
       ffi (~> 1.0)
-    regexp_parser (1.3.0)
+    regexp_parser (1.4.0)
     responders (2.4.1)
       actionpack (>= 4.2.0, < 6.0)
       railties (>= 4.2.0, < 6.0)
@@ -286,7 +286,7 @@ GEM
       activemodel (>= 5.0)
       bindex (>= 0.4.0)
       railties (>= 5.0)
-    webpacker (4.0.2)
+    webpacker (4.0.0)
       activesupport (>= 4.2)
       rack-proxy (>= 0.6.1)
       railties (>= 4.2)
@@ -333,11 +333,11 @@ DEPENDENCIES
   turbolinks (~> 5)
   uglifier (>= 1.3.0)
   web-console (>= 3.3.0)
-  webpacker
-  webpacker-react
+  webpacker (= 4.0.0)
+  webpacker-react (= 0.3.2)
 
 RUBY VERSION
    ruby 2.6.2p47
 
 BUNDLED WITH
-   1.17.2
+   2.0.1

--- a/Gemfile.lock
+++ b/Gemfile.lock
@@ -52,22 +52,6 @@ GEM
     ast (2.4.0)
     autoprefixer-rails (9.5.0)
       execjs
-    aws-eventstream (1.0.2)
-    aws-partitions (1.148.0)
-    aws-sdk-core (3.48.3)
-      aws-eventstream (~> 1.0, >= 1.0.2)
-      aws-partitions (~> 1.0)
-      aws-sigv4 (~> 1.1)
-      jmespath (~> 1.0)
-    aws-sdk-kms (1.16.0)
-      aws-sdk-core (~> 3, >= 3.48.2)
-      aws-sigv4 (~> 1.1)
-    aws-sdk-s3 (1.36.0)
-      aws-sdk-core (~> 3, >= 3.48.2)
-      aws-sdk-kms (~> 1)
-      aws-sigv4 (~> 1.0)
-    aws-sigv4 (1.1.0)
-      aws-eventstream (~> 1.0, >= 1.0.2)
     bcrypt (3.1.12)
     bindex (0.6.0)
     bootsnap (1.4.2)
@@ -133,7 +117,6 @@ GEM
     jbuilder (2.8.0)
       activesupport (>= 4.2.0)
       multi_json (>= 1.2)
-    jmespath (1.4.0)
     json (2.2.0)
     listen (3.1.5)
       rb-fsevent (~> 0.9, >= 0.9.4)
@@ -304,7 +287,6 @@ PLATFORMS
 
 DEPENDENCIES
   acts-as-taggable-on (~> 6.0)
-  aws-sdk-s3
   bootsnap (>= 1.1.0)
   bootstrap (~> 4.3.1)
   brakeman

--- a/config/environments/production.rb
+++ b/config/environments/production.rb
@@ -39,7 +39,7 @@ Rails.application.configure do
   # config.action_dispatch.x_sendfile_header = 'X-Accel-Redirect' # for NGINX
 
   # Store uploaded files on the local file system (see config/storage.yml for options)
-  config.active_storage.service = :amazon
+  # config.active_storage.service = :local
 
   # Mount Action Cable outside main process or domain
   # config.action_cable.mount_path = nil

--- a/config/storage.yml
+++ b/config/storage.yml
@@ -1,34 +1,34 @@
-test:
-  service: Disk
-  root: <%= Rails.root.join("tmp/storage") %>
+# test:
+#   service: Disk
+#   root: <%= Rails.root.join("tmp/storage") %>
 
-local:
-  service: Disk
-  root: <%= Rails.root.join("storage") %>
+# local:
+#   service: Disk
+#   root: <%= Rails.root.join("storage") %>
 
-# Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
-amazon:
-  service: S3
-  access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
-  secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
-  region: us-east-2
-  bucket: reciprocity-photo-uploads
+# # Use rails credentials:edit to set the AWS secrets (as aws:access_key_id|secret_access_key)
+# amazon:
+#   service: S3
+#   access_key_id: <%= Rails.application.credentials.dig(:aws, :access_key_id) %>
+#   secret_access_key: <%= Rails.application.credentials.dig(:aws, :secret_access_key) %>
+#   region: us-east-2
+#   bucket: reciprocity-photo-uploads
 
-# Remember not to checkin your GCS keyfile to a repository
-# google:
-#   service: GCS
-#   project: your_project
-#   credentials: <%= Rails.root.join("path/to/gcs.keyfile") %>
-#   bucket: your_own_bucket
+# # Remember not to checkin your GCS keyfile to a repository
+# # google:
+# #   service: GCS
+# #   project: your_project
+# #   credentials: <%= Rails.root.join("path/to/gcs.keyfile") %>
+# #   bucket: your_own_bucket
 
-# Use rails credentials:edit to set the Azure Storage secret (as azure_storage:storage_access_key)
-# microsoft:
-#   service: AzureStorage
-#   storage_account_name: your_account_name
-#   storage_access_key: <%= Rails.application.credentials.dig(:azure_storage, :storage_access_key) %>
-#   container: your_container_name
+# # Use rails credentials:edit to set the Azure Storage secret (as azure_storage:storage_access_key)
+# # microsoft:
+# #   service: AzureStorage
+# #   storage_account_name: your_account_name
+# #   storage_access_key: <%= Rails.application.credentials.dig(:azure_storage, :storage_access_key) %>
+# #   container: your_container_name
 
-# mirror:
-#   service: Mirror
-#   primary: local
-#   mirrors: [ amazon, google, microsoft ]
+# # mirror:
+# #   service: Mirror
+# #   primary: local
+# #   mirrors: [ amazon, google, microsoft ]


### PR DESCRIPTION
I believe this is the minimal changeset to get us to production. Locking the gem versions (which was probably the problem) and removing active_storage since it dies without aws keys and we haven't configured them.