### PR TITLE
Add tests for listing model

### DIFF
--- a/app/models/listing.rb
+++ b/app/models/listing.rb
@@ -2,5 +2,5 @@ class Listing < ApplicationRecord
   belongs_to :creator, foreign_key: 'created_by_id', class_name: 'Participant'
   has_many_attached :photos
 
-  acts_as_taggable_on :tags
+  acts_as_taggable
 end

--- a/spec/models/listing_spec.rb
+++ b/spec/models/listing_spec.rb
@@ -1,4 +1,15 @@
 require 'rails_helper'
 
 RSpec.describe Listing, type: :model do
+  describe 'belongs_to' do
+    it { is_expected.to belong_to(:creator).class_name('Participant').with_foreign_key('created_by_id') }
+  end
+
+  describe 'has_many' do
+    it { is_expected.to have_many(:photos_attachments) }
+  end
+
+  describe 'acts as taggable' do
+    it { expect(described_class.tag_types).to eq([:tags]) }
+  end
 end


### PR DESCRIPTION
Resolves https://github.com/rubyforgood/reciprocity/issues/148

### Description

This pr is adding the Listing model test, and changing the ```acts_as_taggable_on :tags``` for alias ```acts_as_taggable```

### How Has This Been Tested?

Running rubocop and rspec.
